### PR TITLE
Move school contact step in EOI

### DIFF
--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_does_not_enter_school_contact_details_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_does_not_enter_school_contact_details_spec.rb
@@ -8,14 +8,6 @@ RSpec.describe "School user does not enter school contact details", type: :syste
 
     when_i_select_yes
     and_i_click_on_continue
-    then_i_see_the_education_phase_form_page
-
-    when_i_select_primary
-    and_i_click_on_continue
-    then_i_see_the_year_group_selection_form_page
-
-    when_i_select_year_1
-    and_i_click_on_continue
     then_i_see_the_school_contact_form_page
 
     when_i_click_on_continue
@@ -59,56 +51,6 @@ RSpec.describe "School user does not enter school contact details", type: :syste
   end
   alias_method :and_i_click_on_continue,
                :when_i_click_on_continue
-
-  def then_i_see_the_education_phase_form_page
-    expect(page).to have_title(
-      "What education phase or specialism can your school offer placements in? - Find placement schools",
-    )
-    expect(page).to have_caption("Placement information #{@next_academic_year_short_name}")
-    expect(page).to have_element(
-      :legend,
-      text: "What education phase or specialism can your school offer placements in?",
-      class: "govuk-fieldset__legend",
-    )
-    expect(page).to have_hint("Select all that apply")
-    expect(page).to have_field("Primary", type: :checkbox)
-    expect(page).to have_field("Secondary", type: :checkbox)
-    expect(page).to have_field(
-      "Special educational needs and disabilities (SEND) specific",
-      type: :checkbox,
-    )
-  end
-
-  def when_i_select_primary
-    check "Primary"
-  end
-
-  def then_i_see_the_year_group_selection_form_page
-    expect(page).to have_title(
-      "Which primary year groups can your school offer placements in? - Find placement schools",
-    )
-    expect(page).to have_element(
-      :legend,
-      text: "Which primary year groups can your school offer placements in?",
-      class: "govuk-fieldset__legend",
-    )
-    expect(page).to have_caption(
-      "Primary placement information #{@next_academic_year_short_name}",
-    )
-    expect(page).to have_field("Nursery", type: :checkbox)
-    expect(page).to have_field("Reception", type: :checkbox)
-    expect(page).to have_field("Year 1", type: :checkbox)
-    expect(page).to have_field("Year 2", type: :checkbox)
-    expect(page).to have_field("Year 3", type: :checkbox)
-    expect(page).to have_field("Year 4", type: :checkbox)
-    expect(page).to have_field("Year 5", type: :checkbox)
-    expect(page).to have_field("Year 6", type: :checkbox)
-    expect(page).to have_field("Mixed year groups", type: :checkbox)
-  end
-
-  def when_i_select_year_1
-    check "Year 1"
-  end
 
   def then_i_see_the_school_contact_form_page
     expect(page).to have_title(

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_does_not_select_a_year_group_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe "School user does not select a year group", type: :system do
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_primary
@@ -55,6 +59,26 @@ RSpec.describe "School user does not select a year group", type: :system do
   end
   alias_method :and_i_click_on_continue,
                :when_i_click_on_continue
+
+  def then_i_see_the_school_contact_form_page
+    expect(page).to have_title(
+      "Who should providers contact? - Find placement schools",
+    )
+    expect(page).to have_caption("Placement contact")
+    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_paragraph(
+      "Choose the person best placed to organise placements for trainee teachers at your school",
+    )
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
 
   def then_i_see_the_education_phase_form_page
     expect(page).to have_title(

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/primary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_primary
@@ -17,15 +21,20 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     when_i_select_year_1
     and_i_select_year_5
     and_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-
-    when_i_fill_in_the_school_contact_details
-    and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_change_email_address
     then_i_see_the_school_contact_form_page
     and_i_see_the_school_contact_inputs_prefilled
+
+    when_i_click_on_continue
+    then_i_see_the_education_phase_form_page
+    and_i_see_primary_selected
+
+    when_i_click_on_continue
+    then_i_see_the_year_group_selection_form_page
+    and_i_see_year_1_selected
+    and_i_see_year_5_selected
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page
@@ -34,10 +43,6 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     then_i_see_the_year_group_selection_form_page
     and_i_see_year_1_selected
     and_i_see_year_5_selected
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page
@@ -50,10 +55,6 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     then_i_see_the_year_group_selection_form_page
     and_i_see_year_1_selected
     and_i_see_year_5_selected
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/school_user_does_not_select_a_phase_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/school_user_does_not_select_a_phase_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe "School user does not select a phase", type: :system do
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_click_on_continue
@@ -57,6 +61,26 @@ RSpec.describe "School user does not select a phase", type: :system do
   end
   alias_method :and_i_click_on_continue,
                :when_i_click_on_continue
+
+  def then_i_see_the_school_contact_form_page
+    expect(page).to have_title(
+      "Who should providers contact? - Find placement schools",
+    )
+    expect(page).to have_caption("Placement contact")
+    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_paragraph(
+      "Choose the person best placed to organise placements for trainee teachers at your school",
+    )
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
 
   def then_i_see_the_education_phase_form_page
     expect(page).to have_title(

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_primary
@@ -27,15 +31,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_select_key_stage_2
     and_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-
-    when_i_fill_in_the_school_contact_details
-    and_i_click_on_continue
     then_i_see_the_check_your_answers_page
-
-    when_i_click_on_back
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_back
     then_i_see_the_key_stage_selection_form_page
@@ -54,12 +50,20 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     and_i_see_primary_selected
     and_i_see_secondary_selected
     and_i_see_send_selected
+
+    when_i_click_on_back
+    then_i_see_the_school_contact_form_page
+    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_back
     then_i_see_the_appetite_form_page
     and_i_see_yes_selected
 
     when_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+    and_i_see_the_school_contact_inputs_prefilled
+
+    when_i_click_on_continue
     then_i_see_the_education_phase_form_page
     and_i_see_primary_selected
     and_i_see_secondary_selected
@@ -76,10 +80,6 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     when_i_click_on_continue
     then_i_see_the_key_stage_selection_form_page
     and_i_see_key_stage_2_selected
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_does_not_select_a_child_subject_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "School user successfully adds their hosting interest, including 
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_secondary
@@ -70,6 +74,26 @@ RSpec.describe "School user successfully adds their hosting interest, including 
   end
   alias_method :and_i_click_on_continue,
                :when_i_click_on_continue
+
+  def then_i_see_the_school_contact_form_page
+    expect(page).to have_title(
+      "Who should providers contact? - Find placement schools",
+    )
+    expect(page).to have_caption("Placement contact")
+    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_paragraph(
+      "Choose the person best placed to organise placements for trainee teachers at your school",
+    )
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
 
   def then_i_see_the_education_phase_form_page
     expect(page).to have_title(

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_does_not_select_a_subject_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_secondary
@@ -62,6 +66,26 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
   end
   alias_method :and_i_click_on_continue,
                :when_i_click_on_continue
+
+  def then_i_see_the_school_contact_form_page
+    expect(page).to have_title(
+      "Who should providers contact? - Find placement schools",
+    )
+    expect(page).to have_caption("Placement contact")
+    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_paragraph(
+      "Choose the person best placed to organise placements for trainee teachers at your school",
+    )
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
 
   def then_i_see_the_education_phase_form_page
     expect(page).to have_title(

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_including_a_child_subject_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_including_a_child_subject_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "School user successfully adds their hosting interest, including 
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_secondary
@@ -22,10 +26,6 @@ RSpec.describe "School user successfully adds their hosting interest, including 
     when_i_select_french
     and_i_select_spanish
     and_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-
-    when_i_fill_in_the_school_contact_details
-    and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_change_subject
@@ -36,10 +36,6 @@ RSpec.describe "School user successfully adds their hosting interest, including 
     then_i_see_the_secondary_child_subject_selection_form_page
     and_i_see_french_selected
     and_i_see_spanish_selected
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/secondary_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_secondary
@@ -18,15 +22,20 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     when_i_select_english
     and_i_select_science
     and_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-
-    when_i_fill_in_the_school_contact_details
-    and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_change_email_address
     then_i_see_the_school_contact_form_page
     and_i_see_the_school_contact_inputs_prefilled
+
+    when_i_click_on_continue
+    then_i_see_the_education_phase_form_page
+    and_i_see_secondary_selected
+
+    when_i_click_on_continue
+    then_i_see_the_secondary_subject_selection_form_page
+    and_i_see_english_selected
+    and_i_see_science_selected
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page
@@ -35,10 +44,6 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     then_i_see_the_secondary_subject_selection_form_page
     and_i_see_english_selected
     and_i_see_science_selected
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page
@@ -51,10 +56,6 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     then_i_see_the_secondary_subject_selection_form_page
     and_i_see_english_selected
     and_i_see_science_selected
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/send_phase_only/school_user_does_not_select_a_key_stage_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/send_phase_only/school_user_does_not_select_a_key_stage_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe "School user does not select a key stage", type: :system do
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_send
@@ -55,6 +59,26 @@ RSpec.describe "School user does not select a key stage", type: :system do
   end
   alias_method :and_i_click_on_continue,
                :when_i_click_on_continue
+
+  def then_i_see_the_school_contact_form_page
+    expect(page).to have_title(
+      "Who should providers contact? - Find placement schools",
+    )
+    expect(page).to have_caption("Placement contact")
+    expect(page).to have_h1("Who should providers contact?")
+    expect(page).to have_paragraph(
+      "Choose the person best placed to organise placements for trainee teachers at your school",
+    )
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
 
   def then_i_see_the_education_phase_form_page
     expect(page).to have_title(

--- a/spec/system/placement_preferences/add_hosting_interest/actively_looking/send_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/actively_looking/send_phase_only/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_select_yes
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_send
@@ -18,15 +22,20 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     when_i_select_key_stage_2
     and_i_select_key_state_5
     and_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-
-    when_i_fill_in_the_school_contact_details
-    and_i_click_on_continue
     then_i_see_the_check_your_answers_page
 
     when_i_click_on_change_email_address
     then_i_see_the_school_contact_form_page
     and_i_see_the_school_contact_inputs_prefilled
+
+    when_i_click_on_continue
+    then_i_see_the_education_phase_form_page
+    and_i_see_send_selected
+
+    when_i_click_on_continue
+    then_i_see_the_key_stage_selection_form_page
+    and_i_see_key_stage_2_selected
+    and_i_see_key_stage_5_selected
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page
@@ -35,10 +44,6 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     then_i_see_the_key_stage_selection_form_page
     and_i_see_key_stage_2_selected
     and_i_see_key_stage_5_selected
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page
@@ -51,10 +56,6 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     then_i_see_the_key_stage_selection_form_page
     and_i_see_key_stage_2_selected
     and_i_see_key_stage_5_selected
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_check_your_answers_page

--- a/spec/system/placement_preferences/add_hosting_interest/interested/school_user_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/interested/school_user_adds_their_hosting_interest_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_select_maybe
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_primary
@@ -31,15 +35,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_enter_a_note_to_providers
     and_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-
-    when_i_fill_in_the_school_contact_details
-    and_i_click_on_continue
     then_i_see_the_confirmation_page
-
-    when_i_click_on_back
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_back
     then_i_see_the_note_to_providers_form_page
@@ -63,6 +59,16 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     and_i_see_secondary_selected
     and_i_see_send_selected
 
+    when_i_click_on_back
+    then_i_see_the_school_contact_form_page
+    and_i_see_the_school_contact_inputs_prefilled
+
+    when_i_click_on_continue
+    then_i_see_the_education_phase_form_page
+    and_i_see_primary_selected
+    and_i_see_secondary_selected
+    and_i_see_send_selected
+
     when_i_click_on_continue
     then_i_see_the_year_group_selection_form_page
     and_i_see_i_do_not_know_selected
@@ -80,19 +86,11 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     and_i_see_the_note_i_entered_prefilled
 
     when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
-
-    when_i_click_on_continue
     then_i_see_the_confirmation_page
 
     when_i_click_on_change_message_to_providers
     then_i_see_the_note_to_providers_form_page
     and_i_see_the_note_i_entered_prefilled
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_confirmation_page

--- a/spec/system/placement_preferences/add_hosting_interest/interested/school_user_does_not_know_their_phase_preference_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/interested/school_user_does_not_know_their_phase_preference_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_select_maybe
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_education_phase_form_page
 
     when_i_select_i_do_not_know
@@ -16,15 +20,7 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     then_i_see_the_note_to_providers_form_page
 
     when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-
-    when_i_fill_in_the_school_contact_details
-    and_i_click_on_continue
     then_i_see_the_confirmation_page
-
-    when_i_click_on_back
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_back
     then_i_see_the_note_to_providers_form_page
@@ -33,12 +29,16 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     then_i_see_the_education_phase_form_page
     and_i_see_i_do_not_know_selected
 
-    when_i_click_on_continue
-    then_i_see_the_note_to_providers_form_page
-
-    when_i_click_on_continue
+    when_i_click_on_back
     then_i_see_the_school_contact_form_page
     and_i_see_the_school_contact_inputs_prefilled
+
+    when_i_click_on_continue
+    then_i_see_the_education_phase_form_page
+    and_i_see_i_do_not_know_selected
+
+    when_i_click_on_continue
+    then_i_see_the_note_to_providers_form_page
 
     when_i_click_on_continue
     then_i_see_the_confirmation_page

--- a/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_enter_another_reason_for_not_hosting_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_enter_another_reason_for_not_hosting_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe "School user does not enter another reason for not hosting", type
 
     when_i_select_no
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_reason_for_not_hosting_form_page
 
     when_i_select_other
@@ -52,6 +56,30 @@ RSpec.describe "School user does not enter another reason for not hosting", type
   end
   alias_method :and_i_click_on_continue,
                :when_i_click_on_continue
+
+  def then_i_see_the_school_contact_form_page
+    expect(page).to have_title(
+      "Who can we contact in your school? - Find placement schools",
+    )
+    expect(page).to have_caption("Placement contact")
+    expect(page).to have_h1("Who can we contact in your school?")
+    expect(page).to have_paragraph(
+      "We will email to ask if your school can offer placements for trainee teachers in future academic years.",
+    )
+    expect(page).to have_paragraph(
+      "Choose the person best placed to organise placements for trainee teachers at your school.",
+    )
+
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
 
   def then_i_see_the_reason_for_not_hosting_form_page
     expect(page).to have_title(

--- a/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_enter_school_contact_details_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_enter_school_contact_details_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_select_no
     and_i_click_on_continue
-    then_i_see_the_reason_for_not_hosting_form_page
-
-    when_i_select_no_mentors_available_due_to_capacity
-    and_i_click_on_continue
     then_i_see_the_school_contact_form_page
 
     when_i_click_on_continue

--- a/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_select_a_reason_for_not_hosting_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_does_not_select_a_reason_for_not_hosting_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe "School user does not select a reason for not hosting", type: :sy
 
     when_i_select_no
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_reason_for_not_hosting_form_page
 
     when_i_click_on_continue
@@ -51,6 +55,30 @@ RSpec.describe "School user does not select a reason for not hosting", type: :sy
   end
   alias_method :and_i_click_on_continue,
                :when_i_click_on_continue
+
+  def then_i_see_the_school_contact_form_page
+    expect(page).to have_title(
+      "Who can we contact in your school? - Find placement schools",
+    )
+    expect(page).to have_caption("Placement contact")
+    expect(page).to have_h1("Who can we contact in your school?")
+    expect(page).to have_paragraph(
+      "We will email to ask if your school can offer placements for trainee teachers in future academic years.",
+    )
+    expect(page).to have_paragraph(
+      "Choose the person best placed to organise placements for trainee teachers at your school.",
+    )
+
+    expect(page).to have_field("First name")
+    expect(page).to have_field("Last name")
+    expect(page).to have_field("Email address")
+  end
+
+  def when_i_fill_in_the_school_contact_details
+    fill_in "First name", with: "Joe"
+    fill_in "Last name", with: "Bloggs"
+    fill_in "Email address", with: "joe_bloggs@example.com"
+  end
 
   def then_i_see_the_reason_for_not_hosting_form_page
     expect(page).to have_title(

--- a/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_successfully_adds_their_hosting_interest_spec.rb
+++ b/spec/system/placement_preferences/add_hosting_interest/not_open/school_user_successfully_adds_their_hosting_interest_spec.rb
@@ -8,41 +8,41 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
 
     when_i_select_no
     and_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+
+    when_i_fill_in_the_school_contact_details
+    and_i_click_on_continue
     then_i_see_the_reason_for_not_hosting_form_page
 
     when_i_select_no_mentors_available_due_to_capacity
     and_i_select_other
     and_i_enter_another_reason
     and_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-
-    when_i_fill_in_the_school_contact_details
-    and_i_click_on_continue
     then_i_see_the_are_you_sure_page
     and_i_see_the_reason_not_hosting_i_entered
     and_i_see_the_entered_school_contact_details
 
     when_i_click_on_back
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
-
-    when_i_click_on_back
     then_i_see_the_reason_for_not_hosting_form_page
     and_i_see_no_mentors_available_due_to_capacity_selected
     and_i_see_other_selected
+
+    when_i_click_on_back
+    then_i_see_the_school_contact_form_page
+    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_back
     then_i_see_the_appetite_form_page
     and_i_see_no_selected
 
     when_i_click_on_continue
+    then_i_see_the_school_contact_form_page
+    and_i_see_the_school_contact_inputs_prefilled
+
+    when_i_click_on_continue
     then_i_see_the_reason_for_not_hosting_form_page
     and_i_see_no_mentors_available_due_to_capacity_selected
     and_i_see_other_selected
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_are_you_sure_page
@@ -54,6 +54,11 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
+    then_i_see_the_reason_for_not_hosting_form_page
+    and_i_see_no_mentors_available_due_to_capacity_selected
+    and_i_see_other_selected
+
+    when_i_click_on_continue
     then_i_see_the_are_you_sure_page
     and_i_see_the_entered_school_contact_details
 
@@ -61,10 +66,6 @@ RSpec.describe "School user successfully adds their hosting interest", type: :sy
     then_i_see_the_reason_for_not_hosting_form_page
     and_i_see_no_mentors_available_due_to_capacity_selected
     and_i_see_other_selected
-
-    when_i_click_on_continue
-    then_i_see_the_school_contact_form_page
-    and_i_see_the_school_contact_inputs_prefilled
 
     when_i_click_on_continue
     then_i_see_the_are_you_sure_page

--- a/spec/wizards/add_hosting_interest_wizard_spec.rb
+++ b/spec/wizards/add_hosting_interest_wizard_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AddHostingInterestWizard do
         }
       end
 
-      it { is_expected.to eq %i[appetite phase school_contact check_your_answers] }
+      it { is_expected.to eq %i[appetite school_contact phase check_your_answers] }
 
       context "when the phase is set to 'Primary' during the phase step" do
         let(:state) do
@@ -35,9 +35,9 @@ RSpec.describe AddHostingInterestWizard do
         it {
           expect(steps).to eq(
             %i[appetite
+               school_contact
                phase
                year_group_selection
-               school_contact
                check_your_answers],
           )
         }
@@ -54,9 +54,9 @@ RSpec.describe AddHostingInterestWizard do
         it {
           expect(steps).to eq(
             %i[appetite
+               school_contact
                phase
                secondary_subject_selection
-               school_contact
                check_your_answers],
           )
         }
@@ -78,10 +78,10 @@ RSpec.describe AddHostingInterestWizard do
             expect(steps).to eq(
               [
                 :appetite,
+                :school_contact,
                 :phase,
                 :secondary_subject_selection,
                 "secondary_child_subject_selection_#{modern_languages.id}".to_sym,
-                :school_contact,
                 :check_your_answers
               ]
             )
@@ -100,10 +100,10 @@ RSpec.describe AddHostingInterestWizard do
         it {
           expect(steps).to eq(
             %i[appetite
+               school_contact
                phase
                year_group_selection
                secondary_subject_selection
-               school_contact
                check_your_answers],
           )
         }
@@ -117,7 +117,7 @@ RSpec.describe AddHostingInterestWizard do
         }
       end
 
-      it { is_expected.to eq %i[appetite reason_not_hosting school_contact are_you_sure] }
+      it { is_expected.to eq %i[appetite school_contact reason_not_hosting are_you_sure] }
     end
 
     context "when an appetite is set to 'interested' during the appetite step" do
@@ -127,7 +127,7 @@ RSpec.describe AddHostingInterestWizard do
         }
       end
 
-      it { is_expected.to eq %i[appetite phase note_to_providers school_contact confirm] }
+      it { is_expected.to eq %i[appetite school_contact phase note_to_providers confirm] }
     end
   end
 
@@ -305,13 +305,9 @@ RSpec.describe AddHostingInterestWizard do
       context "when a step is invalid" do
         let(:state) do
           {
-            "appetite" => { "appetite" => "blah" },
+            "appetite" => { "appetite" => "actively_looking" },
             "reason_not_hosting" => {
-              "reasons_not_hosting" => [
-                "Not enough trained mentors",
-                "Number of pupils with SEND needs",
-                "Working to improve our OFSTED rating"
-              ]
+              "reasons_not_hosting" => []
             },
             "school_contact" => {
               "first_name" => "Joe",


### PR DESCRIPTION
## Context

- Move the School Contact step in the EOI to after the appetite is selected.

## Changes proposed in this pull request

- Move the School Contact step in the EOI to after the appetite is selected.
- Save school contact details after entered into the wizard.

## Guidance to review

- Sign in as Anne (School user)
- ⚠️ If you have not yet completed an EOI, the EOI wizard will appear, otherwise, visit `placement_preferences/new` ⚠️ 
- Go through each journey and check that the school contact step appears after selecting each appetite.

## Link to Trello card

https://trello.com/c/S63ORJGd/178-move-contact-details-page-in-expression-of-interest

## Screenshots

https://github.com/user-attachments/assets/42f0b607-fd9a-459a-b98d-1fa3953879f3


