### PR TITLE
Remove debugger gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,9 +74,6 @@ gem "activerecord-session_store"
 gem "pundit"
 
 group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
-
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,9 +134,6 @@ GEM
       railties (>= 6.0.0)
     csv (3.3.5)
     date (3.4.1)
-    debug (1.11.0)
-      irb (~> 1.10)
-      reline (>= 0.3.8)
     diff-lcs (1.6.2)
     docile (1.4.1)
     dotenv (3.1.8)
@@ -655,7 +652,6 @@ DEPENDENCIES
   capybara-screenshot (~> 1.0)
   cssbundling-rails
   csv (~> 3.3)
-  debug
   dotenv-rails (~> 3.1)
   down (~> 5.4)
   draper (~> 4.0)


### PR DESCRIPTION
## Context

Causing issues when building the environment as the flags are being ignored. This gem is not particularly useful so I have opted to remove it.

## Changes proposed in this pull request

- Removes debugger gem